### PR TITLE
Eliminate elliptics cache for task results

### DIFF
--- a/aggregate_core.py
+++ b/aggregate_core.py
@@ -74,16 +74,15 @@ def aggreagate(request, response):
                                           name,
                                           task.CurrTime)
                 try:
-                    data = yield storage.read("combaine", key)
+                    data = task.parsing_result[key]
+                    # data = yield storage.read("combaine", key)
                     subgroup_data.append(data)
                     if cfg.get("perHost"):
                         res = yield app.enqueue("aggregate_group",
                                                 msgpack.packb((task.Id, cfg, [data])))
                         result[name][host] = res
                 except Exception as err:
-                    if err.code != 2:
-                        logger.error("unable to read from cache %s %s",
-                                     key, err)
+                    logger.error("unable to aggregte %s %s %s", name, host, err)
 
             mapping[subgroup] = subgroup_data
             try:
@@ -93,8 +92,7 @@ def aggreagate(request, response):
                             name, subgroup, res)
                 result[name][subgroup] = res
             except Exception as err:
-                logger.error("unable to aggregte %s %s %s",
-                             name, subgroup, err)
+                logger.error("unable to aggregte %s %s %s", name, subgroup, err)
 
         all_data = []
         for v in mapping.itervalues():

--- a/aggregate_core.py
+++ b/aggregate_core.py
@@ -10,9 +10,6 @@ from combaine.common.logger import get_logger_adapter
 from combaine.common import AggregationTask
 
 
-storage = Service("elliptics")
-
-
 class Cache(object):
 
     def __init__(self):
@@ -75,7 +72,6 @@ def aggreagate(request, response):
                                           task.CurrTime)
                 try:
                     data = task.parsing_result[key]
-                    # data = yield storage.read("combaine", key)
                     subgroup_data.append(data)
                     if cfg.get("perHost"):
                         res = yield app.enqueue("aggregate_group",

--- a/cmd/parsing/main.go
+++ b/cmd/parsing/main.go
@@ -26,11 +26,12 @@ func handleTask(request *cocaine.Request, response *cocaine.Response) {
 		response.ErrorMsg(-100, err.Error())
 		return
 	}
-	err = parsing.Parsing(task)
+	result, err := parsing.Parsing(task)
 	if err != nil {
 		response.ErrorMsg(-100, err.Error())
 	} else {
-		response.Write("OK")
+		res, _ := common.Pack(result)
+		response.Write(res)
 	}
 }
 

--- a/combaine/common/__init__.py
+++ b/combaine/common/__init__.py
@@ -108,6 +108,10 @@ class AggregationTask(object):
         except KeyError:
             raise Exception("Malformed task: No Hosts")
 
+    @property
+    def parsing_result(self):
+        return self.task['ParsingResult']
+
 
 class ParsingTask(object):
     def __init__(self, packed_task):

--- a/combainer/client.go
+++ b/combainer/client.go
@@ -229,7 +229,7 @@ func (cl *Client) Dispatch(parsingConfigName string, uniqueID string, shouldWait
 
 	// Parsing phase
 	totalTasksAmount := len(sessionParameters.PTasks)
-	tokens := make(chan<- struct{}, sessionParameters.ParallelParsings)
+	tokens := make(chan struct{}, sessionParameters.ParallelParsings)
 	parsingResult := make(tasks.Result)
 	var mu sync.Mutex
 
@@ -382,9 +382,9 @@ func (cl *Client) doGeneralTask(appName string, task tasks.Task,
 }
 
 func (cl *Client) doParsingTask(task tasks.ParsingTask,
-	wg *sync.WaitGroup, m *sync.Mutex, tokens chan<- struct{},
+	wg *sync.WaitGroup, m *sync.Mutex, tokens <-chan struct{},
 	deadline time.Time, hosts []string, r tasks.Result) {
-	defer func() { tokens <- struct{}{} }() // release
+	defer func() { <-tokens }() // release
 
 	i, err := cl.doGeneralTask(common.PARSING, &task, wg, deadline, hosts)
 	if err != nil {

--- a/combainer/client.go
+++ b/combainer/client.go
@@ -384,6 +384,7 @@ func (cl *Client) doGeneralTask(appName string, task tasks.Task,
 func (cl *Client) doParsingTask(task tasks.ParsingTask,
 	wg *sync.WaitGroup, m *sync.Mutex, tokens chan<- struct{},
 	deadline time.Time, hosts []string, r tasks.Result) {
+	defer func() { tokens <- struct{}{} }() // release
 
 	i, err := cl.doGeneralTask(common.PARSING, &task, wg, deadline, hosts)
 	if err != nil {
@@ -401,7 +402,6 @@ func (cl *Client) doParsingTask(task tasks.ParsingTask,
 	}
 	m.Unlock()
 	cl.clientStats.AddSuccessParsing()
-	tokens <- struct{}{} // release
 
 }
 

--- a/common/configs/combaine.go
+++ b/common/configs/combaine.go
@@ -2,6 +2,7 @@ package configs
 
 // Describes Main section in combaine.yaml
 type MainSection struct {
+	ParallelParsings uint `yaml:ParallelParsings`
 	// Duration of iteration in sec
 	// Pasring stage longs at least 0.8 * MinimumPeriod
 	IterationDuration uint `yaml:"MINIMUM_PERIOD"`

--- a/common/configs/combaine.go
+++ b/common/configs/combaine.go
@@ -2,7 +2,7 @@ package configs
 
 // Describes Main section in combaine.yaml
 type MainSection struct {
-	ParallelParsings uint `yaml:ParallelParsings`
+	ParallelParsings int `yaml:ParallelParsings`
 	// Duration of iteration in sec
 	// Pasring stage longs at least 0.8 * MinimumPeriod
 	IterationDuration uint `yaml:"MINIMUM_PERIOD"`

--- a/common/tasks/core.go
+++ b/common/tasks/core.go
@@ -54,7 +54,7 @@ func (p *ParsingTask) Raw() ([]byte, error) {
 	return common.Pack(p)
 }
 
-type ParsingResult map[string][]byte
+type Result map[string]interface{}
 
 type AggregationTask struct {
 	CommonTask
@@ -68,6 +68,8 @@ type AggregationTask struct {
 	AggregationConfig configs.AggregationConfig
 	// Hosts
 	Hosts hosts.Hosts
+	// ParsingResults
+	ParsingResult Result
 }
 
 // func (a *AggregationTask) Id() string {

--- a/common/tasks/core.go
+++ b/common/tasks/core.go
@@ -54,6 +54,8 @@ func (p *ParsingTask) Raw() ([]byte, error) {
 	return common.Pack(p)
 }
 
+type ParsingResult map[string][]byte
+
 type AggregationTask struct {
 	CommonTask
 	// Name of the current aggregation config

--- a/parsing/parsing.go
+++ b/parsing/parsing.go
@@ -51,7 +51,7 @@ func parseData(task *tasks.ParsingTask, data []byte) ([]byte, error) {
 	return parser.Parse(task.Id, task.ParsingConfig.Parser, data)
 }
 
-func Parsing(task tasks.ParsingTask) (task.ParsingResult, error) {
+func Parsing(task tasks.ParsingTask) (tasks.Result, error) {
 	logger.Infof("%s start parsing", task.Id)
 
 	var (
@@ -105,7 +105,7 @@ func Parsing(task tasks.ParsingTask) (task.ParsingResult, error) {
 		payload = token
 	}
 
-	result := make(task.ParsingResult)
+	result := make(tasks.Result)
 
 	for aggLogName, aggCfg := range task.AggregationConfigs {
 		for k, v := range aggCfg.Data {

--- a/parsing/parsing.go
+++ b/parsing/parsing.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cocaine/cocaine-framework-go/cocaine"
-
 	"github.com/noxiouz/Combaine/common"
 	"github.com/noxiouz/Combaine/common/logger"
 
@@ -14,13 +12,8 @@ import (
 	"github.com/noxiouz/Combaine/common/tasks"
 )
 
-const (
-	storageServiceName = "elliptics"
-)
-
 var (
-	storage *cocaine.Service     = logger.MustCreateService(storageServiceName)
-	cacher  servicecacher.Cacher = servicecacher.NewCacher()
+	cacher servicecacher.Cacher = servicecacher.NewCacher()
 )
 
 func fetchDataFromTarget(task *tasks.ParsingTask) ([]byte, error) {
@@ -58,7 +51,7 @@ func parseData(task *tasks.ParsingTask, data []byte) ([]byte, error) {
 	return parser.Parse(task.Id, task.ParsingConfig.Parser, data)
 }
 
-func Parsing(task tasks.ParsingTask) error {
+func Parsing(task tasks.ParsingTask) (task.ParsingResult, error) {
 	logger.Infof("%s start parsing", task.Id)
 
 	var (
@@ -71,7 +64,7 @@ func Parsing(task tasks.ParsingTask) error {
 	blob, err = fetchDataFromTarget(&task)
 	if err != nil {
 		logger.Errf("%s error `%v` occured while fetching data", task.Id, err)
-		return err
+		return nil, err
 	}
 
 	if !task.ParsingConfig.SkipParsingStage() {
@@ -79,7 +72,7 @@ func Parsing(task tasks.ParsingTask) error {
 		blob, err = parseData(&task, blob)
 		if err != nil {
 			logger.Errf("%s error `%v` occured while parsing data", task.Id, err)
-			return err
+			return nil, err
 		}
 	}
 
@@ -90,18 +83,18 @@ func Parsing(task tasks.ParsingTask) error {
 		datagrid, err := cacher.Get(common.DATABASEAPP)
 		if err != nil {
 			logger.Errf("%s %v", task.Id, err)
-			return err
+			return nil, err
 		}
 
 		res := <-datagrid.Call("enqueue", "put", blob)
 		if err = res.Err(); err != nil {
 			logger.Errf("%s %v", task.Id, err)
-			return err
+			return nil, err
 		}
 		var token string
 		if err = res.Extract(&token); err != nil {
 			logger.Errf("%s %v", task.Id, err)
-			return err
+			return nil, err
 		}
 
 		defer func() {
@@ -112,11 +105,13 @@ func Parsing(task tasks.ParsingTask) error {
 		payload = token
 	}
 
+	result := make(task.ParsingResult)
+
 	for aggLogName, aggCfg := range task.AggregationConfigs {
 		for k, v := range aggCfg.Data {
 			aggType, err := v.Type()
 			if err != nil {
-				return err
+				return nil, err
 			}
 			logger.Debugf("%s Send to %s %s type %s %v", task.Id, aggLogName, k, aggType, v)
 
@@ -156,7 +151,7 @@ func Parsing(task tasks.ParsingTask) error {
 					key := fmt.Sprintf("%s;%s;%s;%s;%v",
 						task.Host, task.ParsingConfigName,
 						logName, k, task.CurrTime)
-					<-storage.Call("cache_write", "combaine", key, raw_res)
+					result[key] = raw_res
 					logger.Debugf("%s Write data with key %s", task.Id, key)
 				case <-time.After(deadline):
 					logger.Errf("%s Failed task %s", task.Id, deadline)
@@ -167,5 +162,5 @@ func Parsing(task tasks.ParsingTask) error {
 	wg.Wait()
 
 	logger.Infof("%s Done", task.Id)
-	return nil
+	return result, nil
 }


### PR DESCRIPTION
All data now passed via cocaine response.
Hosts result collected in simple `map[string]tasks.Result`.
Litle hack for running aggregation locally.
